### PR TITLE
supporting Redis 4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
-# 0.4.2 (2016-mm-dd)
+# 0.5.0 (2018-mm-dd)
 
- -
+ - Upgrades redis to 2.8.0
+ - Support for Redis commands
 
 # 0.4.1 (2016-12-09)
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function RedisPool(opts) {
 
     // add custom Redis commands
     if (this.options.commands && this.options.commands.length) {
-        this.options.commands.forEach(newCommand => {
+        this.options.commands.forEach(function(newCommand) {
             redis.add_command(newCommand);
         });
     }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ var redis = require('redis')
     , util = require('util')
     ;
 
+var FLUSH_CONNECTION = true;
+
 /**
  * Create a new multi database Redis pool.
  * It will emit `status` event with information about each created pool.
@@ -141,7 +143,7 @@ function makePool(options, database) {
                     callbackCalled = true;
                     callback(err, client);
                 }
-                client.end(true);
+                client.end(FLUSH_CONNECTION);
             });
 
             client.on('ready', function () {
@@ -156,7 +158,7 @@ function makePool(options, database) {
 
         destroy: function(client) {
             client.quit();
-            client.end(true);
+            client.end(FLUSH_CONNECTION);
         },
 
         validate: function(client) {

--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ var redis = require('redis')
     , util = require('util')
     ;
     
-redis.add_command('CL.THROTTLE');
-
 /**
  * Create a new multi database Redis pool.
  * It will emit `status` event with information about each created pool.

--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ var redis = require('redis')
     , EventEmitter = require('events').EventEmitter
     , util = require('util')
     ;
-    
+
+// add custom commands
+redis.add_command('CL.THROTTLE');
+
 /**
  * Create a new multi database Redis pool.
  * It will emit `status` event with information about each created pool.

--- a/index.js
+++ b/index.js
@@ -5,9 +5,6 @@ var redis = require('redis')
     , util = require('util')
     ;
 
-// add custom commands
-redis.add_command('CL.THROTTLE');
-
 /**
  * Create a new multi database Redis pool.
  * It will emit `status` event with information about each created pool.
@@ -42,12 +39,20 @@ function RedisPool(opts) {
         },
         emitter: {
             statusInterval: 60000
-        }
+        },
+        commands: []
     };
 
     this.options = _.defaults(opts, defaults);
     this.pools = {};
     this.elapsedThreshold = this.options.slowPool.elapsedThreshold;
+
+    // add custom Redis commands
+    if (this.options.commands && this.options.commands.length) {
+        this.options.commands.forEach(newCommand => {
+            redis.add_command(newCommand);
+        });
+    }
 
     var self = this;
     setInterval(function() {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var redis = require('redis')
     , EventEmitter = require('events').EventEmitter
     , util = require('util')
     ;
-
+    
 
 /**
  * Create a new multi database Redis pool.
@@ -134,7 +134,7 @@ function makePool(options, database) {
                     callbackCalled = true;
                     callback(err, client);
                 }
-                client.end();
+                client.end(true);
             });
 
             client.on('ready', function () {
@@ -144,12 +144,12 @@ function makePool(options, database) {
                         callback(err, client);
                     }
                 });
-            })
+            });
         },
 
         destroy: function(client) {
             client.quit();
-            client.end();
+            client.end(true);
         },
 
         validate: function(client) {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var redis = require('redis')
     , util = require('util')
     ;
     
+redis.add_command('CL.THROTTLE');
 
 /**
  * Create a new multi database Redis pool.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-mpool",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "main": "./index.js",
   "description": "Provides db pools for redis",
   "url": "https://github.com/cartodb/node-redis-mpool",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "test": "./run_tests.sh test/*"
   },
   "engine": {
-    "node": ">= 0.6 < 0.9"
+    "node": ">= 0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,35 +1,39 @@
 {
-    "name": "redis-mpool",
-    "version": "0.4.2",
-    "main": "./index.js",
-    "description": "Provides db pools for redis",
-    "url": "https://github.com/cartodb/node-redis-mpool",
-    "licenses": [{
-        "type": "BSD",
-        "url": "https://github.com/cartodb/node-redis-mpool/blob/master/LICENCE"
-    }],
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/cartodb/node-redis-mpool.git"
-    },
-    "author": "Vizzuality <contact@vizzuality.com> (http://vizzuality.com)",
-    "contributors": [
-      "Simon Tokumine <simon@vizzuality.com>",
-      "Javi Santana <jsantana@vizzuality.com>",
-      "Sandro Santilli <strk@vizzuality.com>"
-    ],
-    "dependencies": {
-        "underscore": "~1.6.0",
-        "generic-pool": "~2.1.1",
-        "redis": "~0.12.1",
-        "hiredis": "~0.5.0"
-    },
-    "devDependencies": {
-        "mocha": "~1.15.1",
-        "step": "~0.0.5"
-    },
-    "scripts": {
-        "test": "./run_tests.sh test/*"
-    },
-    "engine": { "node": ">= 0.6 < 0.9" }
+  "name": "redis-mpool",
+  "version": "0.4.2",
+  "main": "./index.js",
+  "description": "Provides db pools for redis",
+  "url": "https://github.com/cartodb/node-redis-mpool",
+  "licenses": [
+    {
+      "type": "BSD",
+      "url": "https://github.com/cartodb/node-redis-mpool/blob/master/LICENCE"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/cartodb/node-redis-mpool.git"
+  },
+  "author": "Vizzuality <contact@vizzuality.com> (http://vizzuality.com)",
+  "contributors": [
+    "Simon Tokumine <simon@vizzuality.com>",
+    "Javi Santana <jsantana@vizzuality.com>",
+    "Sandro Santilli <strk@vizzuality.com>"
+  ],
+  "dependencies": {
+    "generic-pool": "~2.1.1",
+    "hiredis": "~0.5.0",
+    "redis": "^2.8.0",
+    "underscore": "~1.6.0"
+  },
+  "devDependencies": {
+    "mocha": "~1.15.1",
+    "step": "~0.0.5"
+  },
+  "scripts": {
+    "test": "./run_tests.sh test/*"
+  },
+  "engine": {
+    "node": ">= 0.6 < 0.9"
+  }
 }


### PR DESCRIPTION
Solving a part of CartoDB/Windshaft-cartodb#819
Main PR CartoDB/Windshaft-cartodb#849

Updating node-redis package adding Redis 4 support.

Of course, this change must be work with Redis 3.

`npm` have changed the `package.json` format